### PR TITLE
Adding arvpsdvj

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@
 [Egfia83](https://egfia83.github.io/)
 [aweirth](https://aweirth.github.io/)
 [shouvikantu](https://shouvikantu.github.io/)
+[arvpsdvj](https://arvpsdvj.github.io/)


### PR DESCRIPTION
I am adding arvpsdvj.github.io as a link to the readme in accordance to the first assignment in the DATA 352W class. arvpsdvj is my "pseudonym" that I generated by mashing a few keys on the keyboard.

Signed-off-by: arvpsdvj <123197379+arvpsdvj@users.noreply.github.com>