### PR TITLE
Adding WideningGyre

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@
 [wtreeves](https://treeves-eth23.github.io/)
 [arvpsdvj](https://arvpsdvj.github.io/)
 [MaryR0se](https://maryr0se.github.io/)
+[WideningGyre](https://wideninggyre.github.io)


### PR DESCRIPTION
Pursuant to 1/18 DATA352W assignment on teamwork, adding my pseudonym and a hotlink to my personal webpage to the contributors list within the class repository. I matched the format provided by the repository manager.

Signed-off-by: WideningGyre <123553600+WideningGyre@users.noreply.github.com>